### PR TITLE
feat: adds laravel network validation defaults

### DIFF
--- a/src/ValidationMessages/DefaultMessages.php
+++ b/src/ValidationMessages/DefaultMessages.php
@@ -36,6 +36,10 @@ trait DefaultMessages
         ValidationConstant::RULE_EXISTS,
         ValidationConstant::RULE_UUID,
         ValidationConstant::RULE_AFTER,
+        ValidationConstant::RULE_IP,
+        ValidationConstant::RULE_IPV4,
+        ValidationConstant::RULE_IPV6,
+        ValidationConstant::RULE_MAC_ADDRESS
     ];
 
     public array $addRules = [
@@ -64,6 +68,10 @@ trait DefaultMessages
         ValidationConstant::RULE_EXISTS => ValidationConstant::MESSAGE_KEY_EXISTS,
         ValidationConstant::RULE_UUID => ValidationConstant::MESSAGE_KEY_UUID,
         ValidationConstant::RULE_AFTER => ValidationConstant::MESSAGE_KEY_AFTER,
+        ValidationConstant::RULE_IP => ValidationConstant::MESSAGE_KEY_IP,
+        ValidationConstant::RULE_IPV4 => ValidationConstant::MESSAGE_KEY_IPV4,
+        ValidationConstant::RULE_IPV6 => ValidationConstant::MESSAGE_KEY_IPV6,
+        ValidationConstant::RULE_MAC_ADDRESS => ValidationConstant::MESSAGE_KEY_MAC
     ];
 
     public array $addRulesToMessages = [

--- a/src/ValidationMessages/ValidationConstant.php
+++ b/src/ValidationMessages/ValidationConstant.php
@@ -34,6 +34,10 @@ class ValidationConstant
     public const RULE_EXISTS = 'exists';
     public const RULE_UUID = 'uuid';
     public const RULE_AFTER = 'after';
+    public const RULE_IP = 'ip';
+    public const RULE_IPV4 = 'ipv4';
+    public const RULE_IPV6 = 'ipv6';
+    public const RULE_MAC_ADDRESS = 'mac_address';
 
     public const RULE_NUMERIC = 'numeric';
     public const RULE_VALUE = ':value';
@@ -61,4 +65,8 @@ class ValidationConstant
     public const MESSAGE_KEY_EXISTS = 'The :attribute: doesn\'t exist';
     public const MESSAGE_KEY_UUID = 'The :attribute doesn\'t match UUID format';
     public const MESSAGE_KEY_AFTER = 'The :attribute must be a date after :value.';
+    public const MESSAGE_KEY_IP = 'The :attribute must be a valid IP address';
+    public const MESSAGE_KEY_IPV4 = 'The :attribute must be a valid IPv4 address';
+    public const MESSAGE_KEY_IPV6 = 'The :attribute must be a valid IPv6 address';
+    public const MESSAGE_KEY_MAC = 'The :attribute must be a valid MAC address.';
 }

--- a/tests/Unit/DefaultMessageTest.php
+++ b/tests/Unit/DefaultMessageTest.php
@@ -55,6 +55,10 @@ class DefaultMessageTest extends TestCase
             'field1' => 'regex:/^[\w]+$/',
             'uuid' => 'uuid',
             'field2' => 'after:' . $date,
+            'local_ip' => 'required|ip',
+            'local_ipv4' => 'required|ip|ipv4',
+            'local_ipv6' => 'required|ip|ipv6',
+            'mac_address' => 'required|mac_address'
         ]);
         $messages = $request->messages();
         $this->assertEquals(
@@ -208,6 +212,38 @@ class DefaultMessageTest extends TestCase
                 'field2',
                 $date
             )
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['ip'],
+                'local_ip',
+                '0.0.0.0'
+            ),
+            $messages['local_ip.ip']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['ipv4'],
+                'local_ipv4',
+                '0.0.0.0'
+            ),
+            $messages['local_ipv4.ipv4']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['ipv6'],
+                'local_ipv6',
+                '00:10:0b:de:62:48:ad:5a'
+            ),
+            $messages['local_ipv6.ipv6']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['mac_address'],
+                'mac_address',
+                'xx:xx:xx:xx:xx'
+            ),
+            $messages['mac_address.mac_address']
         );
     }
 


### PR DESCRIPTION
Adds some of the commonly used network validation types

- https://laravel.com/docs/9.x/validation#rule-ip
- https://laravel.com/docs/9.x/validation#ipv4
- https://laravel.com/docs/9.x/validation#ipv6
- https://laravel.com/docs/9.x/validation#rule-mac


Submitting for https://hacktoberfest.com/participation/#pr-mr-details