### PR TITLE
feat: adds laravel starts_with and ends_with validations

### DIFF
--- a/src/ValidationMessages/DefaultMessages.php
+++ b/src/ValidationMessages/DefaultMessages.php
@@ -39,7 +39,9 @@ trait DefaultMessages
         ValidationConstant::RULE_IP,
         ValidationConstant::RULE_IPV4,
         ValidationConstant::RULE_IPV6,
-        ValidationConstant::RULE_MAC_ADDRESS
+        ValidationConstant::RULE_MAC_ADDRESS,
+        ValidationConstant::RULE_STARTS_WITH,
+        ValidationConstant::RULE_ENDS_WITH,
     ];
 
     public array $addRules = [
@@ -71,7 +73,9 @@ trait DefaultMessages
         ValidationConstant::RULE_IP => ValidationConstant::MESSAGE_KEY_IP,
         ValidationConstant::RULE_IPV4 => ValidationConstant::MESSAGE_KEY_IPV4,
         ValidationConstant::RULE_IPV6 => ValidationConstant::MESSAGE_KEY_IPV6,
-        ValidationConstant::RULE_MAC_ADDRESS => ValidationConstant::MESSAGE_KEY_MAC
+        ValidationConstant::RULE_MAC_ADDRESS => ValidationConstant::MESSAGE_KEY_MAC,
+        ValidationConstant::RULE_STARTS_WITH => ValidationConstant::MESSAGE_KEY_STARTS_WITH,
+        ValidationConstant::RULE_ENDS_WITH => ValidationConstant::MESSAGE_KEY_ENDS_WITH,
     ];
 
     public array $addRulesToMessages = [

--- a/src/ValidationMessages/ValidationConstant.php
+++ b/src/ValidationMessages/ValidationConstant.php
@@ -38,6 +38,8 @@ class ValidationConstant
     public const RULE_IPV4 = 'ipv4';
     public const RULE_IPV6 = 'ipv6';
     public const RULE_MAC_ADDRESS = 'mac_address';
+    public const RULE_STARTS_WITH = 'starts_with';
+    public const RULE_ENDS_WITH = 'ends_with';
 
     public const RULE_NUMERIC = 'numeric';
     public const RULE_VALUE = ':value';
@@ -69,4 +71,6 @@ class ValidationConstant
     public const MESSAGE_KEY_IPV4 = 'The :attribute must be a valid IPv4 address';
     public const MESSAGE_KEY_IPV6 = 'The :attribute must be a valid IPv6 address';
     public const MESSAGE_KEY_MAC = 'The :attribute must be a valid MAC address.';
+    public const MESSAGE_KEY_STARTS_WITH = 'The :attribute should start with :value';
+    public const MESSAGE_KEY_ENDS_WITH = 'The :attribute should end with :value';
 }

--- a/tests/Unit/DefaultMessageTest.php
+++ b/tests/Unit/DefaultMessageTest.php
@@ -58,7 +58,9 @@ class DefaultMessageTest extends TestCase
             'local_ip' => 'required|ip',
             'local_ipv4' => 'required|ip|ipv4',
             'local_ipv6' => 'required|ip|ipv6',
-            'mac_address' => 'required|mac_address'
+            'mac_address' => 'required|mac_address',
+            'starts_with' => 'required|starts_with:foo',
+            'ends_with' => 'required|ends_with:bar',
         ]);
         $messages = $request->messages();
         $this->assertEquals(
@@ -244,6 +246,22 @@ class DefaultMessageTest extends TestCase
                 'xx:xx:xx:xx:xx'
             ),
             $messages['mac_address.mac_address']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['starts_with'],
+                'starts_with',
+                'foo'
+            ),
+            $messages['starts_with.starts_with']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['ends_with'],
+                'ends_with',
+                'bar'
+            ),
+            $messages['ends_with.ends_with']
         );
     }
 


### PR DESCRIPTION
Adds some of the commonly validation types:

- [https://laravel.com/docs/9.x/validation#rule-starts-with](https://laravel.com/docs/9.x/validation#rule-starts-with)
- [https://laravel.com/docs/9.x/validation#rule-ends-with](https://laravel.com/docs/9.x/validation#rule-ends-with)

Submitting for [https://hacktoberfest.com/participation/#pr-mr-details](https://hacktoberfest.com/participation/#pr-mr-details)