### PR TITLE
feat: adds laravel doesnt_start_with and doesnt_end_with validations

### DIFF
--- a/src/ValidationMessages/DefaultMessages.php
+++ b/src/ValidationMessages/DefaultMessages.php
@@ -42,6 +42,8 @@ trait DefaultMessages
         ValidationConstant::RULE_MAC_ADDRESS,
         ValidationConstant::RULE_STARTS_WITH,
         ValidationConstant::RULE_ENDS_WITH,
+        ValidationConstant::RULE_DOESNT_START_WITH,
+        ValidationConstant::RULE_DOESNT_END_WITH,
     ];
 
     public array $addRules = [
@@ -76,6 +78,8 @@ trait DefaultMessages
         ValidationConstant::RULE_MAC_ADDRESS => ValidationConstant::MESSAGE_KEY_MAC,
         ValidationConstant::RULE_STARTS_WITH => ValidationConstant::MESSAGE_KEY_STARTS_WITH,
         ValidationConstant::RULE_ENDS_WITH => ValidationConstant::MESSAGE_KEY_ENDS_WITH,
+        ValidationConstant::RULE_DOESNT_START_WITH => ValidationConstant::MESSAGE_KEY_DOESNT_START_WITH,
+        ValidationConstant::RULE_DOESNT_END_WITH => ValidationConstant::MESSAGE_KEY_DOESNT_END_WITH,
     ];
 
     public array $addRulesToMessages = [

--- a/src/ValidationMessages/ValidationConstant.php
+++ b/src/ValidationMessages/ValidationConstant.php
@@ -40,6 +40,9 @@ class ValidationConstant
     public const RULE_MAC_ADDRESS = 'mac_address';
     public const RULE_STARTS_WITH = 'starts_with';
     public const RULE_ENDS_WITH = 'ends_with';
+    public const RULE_DOESNT_START_WITH = 'doesnt_start_with';
+    public const RULE_DOESNT_END_WITH = 'doesnt_end_with';
+    public const RULE_MULTIPLE_OF = 'multiple_of';
 
     public const RULE_NUMERIC = 'numeric';
     public const RULE_VALUE = ':value';
@@ -73,4 +76,6 @@ class ValidationConstant
     public const MESSAGE_KEY_MAC = 'The :attribute must be a valid MAC address.';
     public const MESSAGE_KEY_STARTS_WITH = 'The :attribute should start with :value';
     public const MESSAGE_KEY_ENDS_WITH = 'The :attribute should end with :value';
+    public const MESSAGE_KEY_DOESNT_START_WITH = 'The :attribute cannot start with :value';
+    public const MESSAGE_KEY_DOESNT_END_WITH = 'The :attribute cannot end with :value';
 }

--- a/tests/Unit/DefaultMessageTest.php
+++ b/tests/Unit/DefaultMessageTest.php
@@ -61,6 +61,9 @@ class DefaultMessageTest extends TestCase
             'mac_address' => 'required|mac_address',
             'starts_with' => 'required|starts_with:foo',
             'ends_with' => 'required|ends_with:bar',
+            'doesnt_start_with' => 'required|doesnt_start_with:cannot_foo',
+            'doesnt_end_with' => 'required|doesnt_end_with:cannot_bar',
+            'multiple_of' => 'required|multiple_of:2'
         ]);
         $messages = $request->messages();
         $this->assertEquals(
@@ -262,6 +265,22 @@ class DefaultMessageTest extends TestCase
                 'bar'
             ),
             $messages['ends_with.ends_with']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['doesnt_start_with'],
+                'doesnt_start_with',
+                'cannot_foo'
+            ),
+            $messages['doesnt_start_with.doesnt_start_with']
+        );
+        $this->assertEquals(
+            $this->createKeyValueMessages(
+                $request->getRulesToMessages()['doesnt_end_with'],
+                'doesnt_end_with',
+                'cannot_bar'
+            ),
+            $messages['doesnt_end_with.doesnt_end_with']
         );
     }
 


### PR DESCRIPTION
Adds some of the commonly validation types:

- [https://laravel.com/docs/9.x/validation#rule-doesnt-start-with](https://laravel.com/docs/9.x/validation#rule-doesnt-start-with)
- [https://laravel.com/docs/9.x/validation#rule-doesnt-end-with](https://laravel.com/docs/9.x/validation#rule-doesnt-end-with)

Submitting for [https://hacktoberfest.com/participation/#pr-mr-details](https://hacktoberfest.com/participation/#pr-mr-details)

If accept, please put `hacktoberfest-accepted` label :pray: 